### PR TITLE
Use skip=, not deprecated autostart=

### DIFF
--- a/R/query.ucsc.R
+++ b/R/query.ucsc.R
@@ -111,11 +111,11 @@ query.ucsc <- function(x, mirror = "http://hgdownload.soe.ucsc.edu/goldenPath/hg
 		data.file <- data.file.tmp;
 		#ucsc.table <- read.table(data.file, as.is = TRUE, sep = "\t", col.names = table.names, colClasses = var.types );
         ucsc.table <- try(fread(data.file, stringsAsFactors = FALSE, sep = "\t", colClasses = var.types), silent = TRUE);
-        i.autostart <- 2;
+        i.skip <- 2;
         while (length(ucsc.table)!=length(table.names)) {
-            ucsc.table <- try(fread(data.file, stringsAsFactors = FALSE, sep = "\t", colClasses = var.types, autostart = i.autostart), silent = TRUE);
-            i.autostart <- 2+1;
-            if (i.autostart == 100 ) break
+            ucsc.table <- try(fread(data.file, stringsAsFactors = FALSE, sep = "\t", colClasses = var.types, skip = i.skip), silent = TRUE);
+            i.skip <- 2+1;
+            if (i.skip == 100 ) break
             }
 		ucsc.table <- setNames(ucsc.table, table.names)
 		ucsc.table <- as.data.frame(ucsc.table);


### PR DESCRIPTION
Closes #18

Already from {data.table} 1.17.0, using `autostart=` is a run-time error, but the `try()` wrapping is hiding that issue.

From 1.17.99 (to be 1.18.0 on CRAN), `autostart=` is no longer in the signature, so `R CMD check` will flag the improper function call by static analysis.

Anyway, the canonical way for many years to specify "start reading at line `n`" with `fread()` is `skip=n`.