### PR TITLE
Bump R-CMD-check-action to v2

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: r-lib/actions/setup-tinytex@v2
-      - uses: uclahs-cds/tool-R-CMD-check-action@renv
+      - uses: uclahs-cds/tool-R-CMD-check-action@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: bedr
 Type: Package
 Title: Genomic Region Processing using Tools Such as 'BEDTools', 'BEDOPS' and 'Tabix'
-Version: 1.1.3
-Date: 2025-04-04
+Version: 1.1.4
+Date: 2025-06-17
 Authors@R: c(
   person("Syed", "Haider", role = "aut"),
   person("Daryl", "Waggott", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# bedr 1.1.4 (2025-06-17)
+
+
+## Changed
+
+- Use updated `R CMD check` CI/CD action.
+
+
 # bedr 1.1.3 (2025-04-04)
 
 


### PR DESCRIPTION
This PR updates the `R CMD check` action to its newest `v2` release.
